### PR TITLE
Fix excessive CPU usage by using SetCommTimeouts

### DIFF
--- a/SimpleCom/SimpleCom.cpp
+++ b/SimpleCom/SimpleCom.cpp
@@ -177,6 +177,15 @@ int _tmain(int argc, LPCTSTR argv[])
 	SetCommMask(hSerial, EV_RXCHAR);
 	SetupComm(hSerial, 1, 1);
 
+	COMMTIMEOUTS comm_timeouts;
+	GetCommTimeouts(hSerial, &comm_timeouts);
+	comm_timeouts.ReadIntervalTimeout = 1;
+	comm_timeouts.ReadTotalTimeoutMultiplier = 0;
+	comm_timeouts.ReadTotalTimeoutConstant = 10;
+	comm_timeouts.WriteTotalTimeoutMultiplier = 0;
+	comm_timeouts.WriteTotalTimeoutConstant = 0;
+	SetCommTimeouts(hSerial, &comm_timeouts);
+
 	serialReadOverlapped.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
 	if (serialReadOverlapped.hEvent == NULL) {
 		WinAPIException ex(GetLastError(), _T("SimpleCom"));

--- a/SimpleCom/SimpleCom.cpp
+++ b/SimpleCom/SimpleCom.cpp
@@ -187,6 +187,11 @@ int _tmain(int argc, LPCTSTR argv[])
 	SetCommTimeouts(hSerial, &comm_timeouts);
 
 	serialReadOverlapped.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+	serialReadOverlapped.Internal = 0;
+	serialReadOverlapped.InternalHigh = 0;
+	serialReadOverlapped.Offset = 0;
+	serialReadOverlapped.OffsetHigh = 0;
+	
 	if (serialReadOverlapped.hEvent == NULL) {
 		WinAPIException ex(GetLastError(), _T("SimpleCom"));
 		MessageBox(parent_hwnd, ex.GetErrorText(), ex.GetErrorCaption(), MB_OK | MB_ICONERROR);


### PR DESCRIPTION
Closes #8 

As mentioned in https://github.com/YaSuenag/SimpleCom/issues/2#issuecomment-813677549, the high CPU was caused by an interaction with other programs that were resetting the COM port timeouts on exit. TeraTerm specifically was resetting the timeouts on close. When SimpleCom opened the serial port after TeraTerm had closed it, the reset the value to `MAXDWORD` ([see code](https://osdn.net/projects/ttssh2/scm/svn/blobs/head/trunk/teraterm/teraterm/commlib.c)) resulted constant CPU polling instead of waiting for the overlapped event.

The fix is to set the expected timeouts on COM port open.

This pull request also clears the `serialReadOverlapped` structure on creation, just to be tidy.