### PR TITLE
Miscellaneous improvements

### DIFF
--- a/SimpleCom/EnumValue.h
+++ b/SimpleCom/EnumValue.h
@@ -18,7 +18,7 @@
  */
 #pragma once
 
-#include <Windows.h>
+#include "stdafx.h"
 
 /*
  * Base class for enum value.

--- a/SimpleCom/SerialSetup.cpp
+++ b/SimpleCom/SerialSetup.cpp
@@ -16,12 +16,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301, USA.
  */
-#include <Windows.h>
-#include <tchar.h>
+#include "stdafx.h"
 
 #include <regex>
 
 #include "SerialSetup.h"
+
 #include "WinAPIException.h"
 #include "resource.h"
 

--- a/SimpleCom/SerialSetup.h
+++ b/SimpleCom/SerialSetup.h
@@ -18,8 +18,7 @@
  */
 #pragma once
 
-#include <Windows.h>
-#include <tchar.h>
+#include "stdafx.h"
 
 #include <map>
 #include <string>

--- a/SimpleCom/SerialSetup.h
+++ b/SimpleCom/SerialSetup.h
@@ -45,8 +45,12 @@ public:
 	constexpr explicit StopBits(const int value, LPCTSTR str) noexcept : EnumValue(value, str) {};
 };
 
+#ifdef  UNICODE
+typedef std::wstring TString;
+#else   /* UNICODE */
+typedef std::string TString;
+#endif /* UNICODE */
 
-typedef std::basic_string<TCHAR> TString;
 typedef std::map<TString, TString> TDeviceMap;
 
 /*

--- a/SimpleCom/SimpleCom.cpp
+++ b/SimpleCom/SimpleCom.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (C) 2019, 2021, Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
@@ -16,9 +16,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301, USA.
  */
-#define _CRT_SECURE_NO_WARNINGS
+#include "stdafx.h"
 
-#include <Windows.h>
+#define _CRT_SECURE_NO_WARNINGS
 
 #include <iostream>
 

--- a/SimpleCom/SimpleCom.cpp
+++ b/SimpleCom/SimpleCom.cpp
@@ -18,8 +18,6 @@
  */
 #include "stdafx.h"
 
-#define _CRT_SECURE_NO_WARNINGS
-
 #include <iostream>
 
 #include "SerialSetup.h"

--- a/SimpleCom/SimpleCom.vcxproj
+++ b/SimpleCom/SimpleCom.vcxproj
@@ -143,6 +143,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/SimpleCom/SimpleCom.vcxproj
+++ b/SimpleCom/SimpleCom.vcxproj
@@ -99,8 +99,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
@@ -136,8 +135,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -156,12 +154,16 @@
   <ItemGroup>
     <ClCompile Include="SerialSetup.cpp" />
     <ClCompile Include="SimpleCom.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="WinAPIException.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="EnumValue.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SerialSetup.h" />
+    <ClInclude Include="stdafx.h" />
     <ClInclude Include="WinAPIException.h" />
   </ItemGroup>
   <ItemGroup>

--- a/SimpleCom/SimpleCom.vcxproj
+++ b/SimpleCom/SimpleCom.vcxproj
@@ -111,6 +111,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>app.manifest</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -163,6 +166,9 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="SerialSetupResource.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="app.manifest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/SimpleCom/SimpleCom.vcxproj.filters
+++ b/SimpleCom/SimpleCom.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="WinAPIException.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="stdafx.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SerialSetup.h">
@@ -36,6 +39,9 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
     <ClInclude Include="EnumValue.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="stdafx.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SimpleCom/SimpleCom.vcxproj.filters
+++ b/SimpleCom/SimpleCom.vcxproj.filters
@@ -44,4 +44,7 @@
       <Filter>リソース ファイル</Filter>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="app.manifest" />
+  </ItemGroup>
 </Project>

--- a/SimpleCom/WinAPIException.cpp
+++ b/SimpleCom/WinAPIException.cpp
@@ -16,8 +16,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301, USA.
  */
-#include "WinAPIException.h"
+#include "stdafx.h"
 
+#include "WinAPIException.h"
 
 
 WinAPIException::WinAPIException(DWORD error_code, LPCTSTR error_caption) : _error_code(error_code),

--- a/SimpleCom/WinAPIException.h
+++ b/SimpleCom/WinAPIException.h
@@ -33,19 +33,19 @@ private:
 	LPTSTR _error_text;
 
 public:
-	WinAPIException(DWORD error_code) : WinAPIException(error_code, _T("SimpleCom")) {};
+	explicit WinAPIException(DWORD error_code) : WinAPIException(error_code, _T("SimpleCom")) {}
 	WinAPIException(DWORD error_code, LPCTSTR error_caption);
 	virtual ~WinAPIException();
 
-	inline DWORD GetErrorCode() noexcept {
+	inline DWORD GetErrorCode() const noexcept {
 		return _error_code;
 	}
 
-	inline LPCTSTR GetErrorCaption() noexcept {
+	inline LPCTSTR GetErrorCaption() const noexcept {
 		return _error_caption;
 	}
 
-	inline LPTSTR GetErrorText() noexcept {
+	inline LPCTSTR GetErrorText() const noexcept {
 		return _error_text;
 	}
 };

--- a/SimpleCom/WinAPIException.h
+++ b/SimpleCom/WinAPIException.h
@@ -18,9 +18,7 @@
  */
 #pragma once
 
-#include <Windows.h>
-#include <tchar.h>
-
+#include "stdafx.h"
 
 /*
  * Exception class for Windows API error.

--- a/SimpleCom/app.manifest
+++ b/SimpleCom/app.manifest
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity version="1.0.0.0" name="SimpleCom.exe"/>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" maxversiontested="10.0.19042.868" />
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+    </application>
+  </compatibility>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/SimpleCom/stdafx.cpp
+++ b/SimpleCom/stdafx.cpp
@@ -1,0 +1,1 @@
+#include "stdafx.h"

--- a/SimpleCom/stdafx.h
+++ b/SimpleCom/stdafx.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Windows Version
+#include <winsdkver.h>
+#define WINVER _WIN32_WINNT_WINBLUE
+#define _WIN32_WINNT _WIN32_WINNT_WINBLUE
+#include <sdkddkver.h>
+
+// System Includes
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <tchar.h>


### PR DESCRIPTION
* Use full definition for std::wstring.
* Add .manifest file to target Windows 10. Eliminates Windows API compatibility modes on newer OSs.
* Add precompiled header. Set Windows SDK version to Windows 8.1.
* Statically link runtime library for release. Makes exe slightly bigger, but ensures no DLL dependancies.
* Make WinAPIException safer. Add `explicit` and `const` to class.