### PR TITLE
Refactoring TTY Resizer related code

### DIFF
--- a/SimpleCom/SerialConnection.cpp
+++ b/SimpleCom/SerialConnection.cpp
@@ -201,7 +201,7 @@ bool SimpleCom::SerialConnection::StdInRedirector(const HANDLE hSerial, const HA
 					}
 					else if ((inputs[idx].EventType == WINDOW_BUFFER_SIZE_EVENT) && _useTTYResizer) {
 						char buf[RINGBUF_SZ];
-						int len = snprintf(buf, sizeof(buf), "%c%d%c%d%c", RESIZER_START_MARKER, inputs[idx].Event.WindowBufferSizeEvent.dwSize.Y, RESIZER_SEPARATOR, inputs[idx].Event.WindowBufferSizeEvent.dwSize.X, RESIZER_END_MARKER);
+						int len = snprintf(buf, sizeof(buf), "%c%d" RESIZER_SEPARATOR "%d%c", RESIZER_START_MARKER, inputs[idx].Event.WindowBufferSizeEvent.dwSize.Y, inputs[idx].Event.WindowBufferSizeEvent.dwSize.X, RESIZER_END_MARKER);
 						writer.PutData(buf, len);
 					}
 				}

--- a/SimpleCom/SerialConnection.cpp
+++ b/SimpleCom/SerialConnection.cpp
@@ -20,6 +20,7 @@
 #include "SerialConnection.h"
 #include "util.h"
 #include "debug.h"
+#include "../common/common.h"
 
 static constexpr int buf_sz = 256;
 
@@ -199,10 +200,9 @@ bool SimpleCom::SerialConnection::StdInRedirector(const HANDLE hSerial, const HA
 						}
 					}
 					else if ((inputs[idx].EventType == WINDOW_BUFFER_SIZE_EVENT) && _useTTYResizer) {
-						char buf[buf_sz];
-						buf[0] = '\x05';
-						int len = snprintf(&buf[1], buf_sz, "%d;%dt", inputs[idx].Event.WindowBufferSizeEvent.dwSize.Y, inputs[idx].Event.WindowBufferSizeEvent.dwSize.X);
-						writer.PutData(buf, len + 1); // "len" excludes the marker (0x05)
+						char buf[RINGBUF_SZ];
+						int len = snprintf(buf, sizeof(buf), "%c%d%c%d%c", RESIZER_START_MARKER, inputs[idx].Event.WindowBufferSizeEvent.dwSize.Y, RESIZER_SEPARATOR, inputs[idx].Event.WindowBufferSizeEvent.dwSize.X, RESIZER_END_MARKER);
+						writer.PutData(buf, len);
 					}
 				}
 

--- a/SimpleCom/SimpleCom.vcxproj
+++ b/SimpleCom/SimpleCom.vcxproj
@@ -183,6 +183,7 @@
     <ClCompile Include="WinAPIException.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\common\common.h" />
     <ClInclude Include="debug.h" />
     <ClInclude Include="EnumValue.h" />
     <ClInclude Include="resource.h" />

--- a/SimpleCom/SimpleCom.vcxproj.filters
+++ b/SimpleCom/SimpleCom.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClInclude Include="SerialConnection.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
+    <ClInclude Include="..\common\common.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="SimpleCom.rc">

--- a/common/common.h
+++ b/common/common.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023, Yasumasa Suenaga
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+#ifndef COMMON_H
+#define COMMON_H
+
+#define RESIZER_START_MARKER  '\x05'
+#define RESIZER_END_MARKER    't'
+#define RESIZER_CANCEL_MARKER 'c'
+#define RESIZER_SEPARATOR     ';'
+
+/* marker (0x05) + ushort (up to 65535) + separator (;) + ushort + end marker */
+#define RINGBUF_SZ 13
+
+#endif

--- a/common/common.h
+++ b/common/common.h
@@ -22,7 +22,7 @@
 #define RESIZER_START_MARKER  '\x05'
 #define RESIZER_END_MARKER    't'
 #define RESIZER_CANCEL_MARKER 'c'
-#define RESIZER_SEPARATOR     ';'
+#define RESIZER_SEPARATOR     ";"
 
 /* marker (0x05) + ushort (up to 65535) + separator (;) + ushort + end marker */
 #define RINGBUF_SZ 13

--- a/tty-resizer/Makefile
+++ b/tty-resizer/Makefile
@@ -10,7 +10,7 @@ CPPFLAGS = -I$(KERNEL_DEVEL_ROOT) -I../common
 LDFLAGS = -lbpf
 
 all: tty-resizer.skel.h
-	$(CC) $(CFLAGS) -c tty-resizer.c -o tty-resizer.o
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c tty-resizer.c -o tty-resizer.o
 	$(CC) $(CFLAGS) tty-resizer.o -o $(TARGET) $(LDFLAGS)
 
 tty-resizer.skel.h: tty-resizer.bpf.o

--- a/tty-resizer/Makefile
+++ b/tty-resizer/Makefile
@@ -6,7 +6,7 @@ CC := clang
 BPFTOOL := bpftool
 
 CFLAGS = -g -O2 -Wall
-CPPFLAGS = -I$(KERNEL_DEVEL_ROOT)
+CPPFLAGS = -I$(KERNEL_DEVEL_ROOT) -I../common
 LDFLAGS = -lbpf
 
 all: tty-resizer.skel.h

--- a/tty-resizer/tty-resizer.bpf.c
+++ b/tty-resizer/tty-resizer.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(tty_read, struct kiocb *iocb, struct iov_iter *to, int ret){
       flags = BPF_RB_FORCE_WAKEUP;
       send_to_buffer = false;
     }
-    else if((ch != RESIZER_SEPARATOR) && (('0' > ch) || ('9' < ch))){
+    else if((ch != *RESIZER_SEPARATOR) && (('0' > ch) || ('9' < ch))){
       /* handles invalid chars */
       ch = RESIZER_CANCEL_MARKER;
       flags = BPF_RB_FORCE_WAKEUP;

--- a/tty-resizer/tty-resizer.bpf.c
+++ b/tty-resizer/tty-resizer.bpf.c
@@ -21,7 +21,7 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 
-#define RINGBUF_SZ 10
+#include "common.h"
 
 char LICENSE[] SEC("license") = "GPL";
 
@@ -46,7 +46,7 @@ int BPF_PROG(tty_read, struct kiocb *iocb, struct iov_iter *to, int ret){
 
   ubuf = BPF_CORE_READ(to, ubuf);
   bpf_probe_read_user(&ch, 1, ubuf);
-  if(ch == '\x05'){
+  if(ch == RESIZER_START_MARKER){
     send_to_buffer = true;
 
     ch = '\0';
@@ -54,13 +54,13 @@ int BPF_PROG(tty_read, struct kiocb *iocb, struct iov_iter *to, int ret){
   }
   else if(send_to_buffer){
     u64 flags = BPF_RB_NO_WAKEUP;
-    if(ch == 't'){
+    if(ch == RESIZER_END_MARKER){
       flags = BPF_RB_FORCE_WAKEUP;
       send_to_buffer = false;
     }
-    else if((ch != ';') && (('0' > ch) || ('9' < ch))){
+    else if((ch != RESIZER_SEPARATOR) && (('0' > ch) || ('9' < ch))){
       /* handles invalid chars */
-      ch = 'c';
+      ch = RESIZER_CANCEL_MARKER;
       flags = BPF_RB_FORCE_WAKEUP;
       send_to_buffer = false;
     }

--- a/tty-resizer/tty-resizer.c
+++ b/tty-resizer/tty-resizer.c
@@ -46,7 +46,7 @@ int on_char_received(void *ctx, void *data, size_t size){
   ch = *(char *)data;
   if(ch == 't'){
     ringbuf_received[ringbuf_received_idx] = '\0';
-    if(sscanf(ringbuf_received, "%hu%c%hu", &ws.ws_row, RESIZER_SEPARATOR, &ws.ws_col) == 2){
+    if(sscanf(ringbuf_received, "%hu" RESIZER_SEPARATOR "%hu", &ws.ws_row, &ws.ws_col) == 2){
       if(ioctl(tty_fd, TIOCSWINSZ, &ws) == -1){
         perror("ioctl");
         _exit(-200);

--- a/tty-resizer/tty-resizer.c
+++ b/tty-resizer/tty-resizer.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <bpf/libbpf.h>
 #include "tty-resizer.skel.h"
+#include "common.h"
 
 
 static int tty_fd = -1;
@@ -45,7 +46,7 @@ int on_char_received(void *ctx, void *data, size_t size){
   ch = *(char *)data;
   if(ch == 't'){
     ringbuf_received[ringbuf_received_idx] = '\0';
-    if(sscanf(ringbuf_received, "%hu;%hu", &ws.ws_row, &ws.ws_col) == 2){
+    if(sscanf(ringbuf_received, "%hu%c%hu", &ws.ws_row, RESIZER_SEPARATOR, &ws.ws_col) == 2){
       if(ioctl(tty_fd, TIOCSWINSZ, &ws) == -1){
         perror("ioctl");
         _exit(-200);


### PR DESCRIPTION
* Add `common.h` to define common macros between SimpleCom and TTY Resizer
* Update ring buffer size to use eBPF
* Refine both code (SimpleCom, TTY Resizer"