### PR TITLE
F1 key does not work on modern Windows 11

### DIFF
--- a/SimpleCom/SerialConnection.h
+++ b/SimpleCom/SerialConnection.h
@@ -38,7 +38,8 @@ namespace SimpleCom {
 		bool _enableStdinLogging;
 
 		void InitSerialPort(const HANDLE hSerial);
-		bool ProcessKeyEvents(const KEY_EVENT_RECORD keyevent, SerialPortWriter& writer, const HANDLE hTermEvent);
+		bool ShouldTerminate(SerialPortWriter& writer, const HANDLE hTermEvent);
+		void ProcessKeyEvents(const KEY_EVENT_RECORD keyevent, SerialPortWriter& writer);
 		bool StdInRedirector(const HANDLE hSerial, const HANDLE hTermEvent);
 
 	public:


### PR DESCRIPTION
Relates to #44

This issue is caused by:
https://github.com/YaSuenag/SimpleCom/commit/939f11d03852a2c2f5818afa18e7dfbf933592c6

This change worked at the timing of the commit (Jan 6 2024) at least, but it does not work at June 22 2024 on Windows 11 23H2 (22631.3737). So I guess this bug is closely related to Windows updates between Jan 2024 and June 2024, but I could not figure out the KB which relates to this.