### PR TITLE
Handles serial controller removal

### DIFF
--- a/SimpleCom/SerialConnection.cpp
+++ b/SimpleCom/SerialConnection.cpp
@@ -317,7 +317,9 @@ bool SimpleCom::SerialConnection::DoSession(bool allowDetachDevice) {
 		case ERROR_ACCESS_DENIED:
 		case ERROR_BAD_COMMAND:
 		case ERROR_DEVICE_REMOVED:
-			if (allowDetachDevice) {
+			if (ex.IsSerialAPIException() && allowDetachDevice) {
+				debug::log(_T("SerialAPIException occurred, but error dialog was suppressed because allowDetachDevice is false."));
+				debug::log(ex.GetErrorText().c_str());
 				continue;
 			}
 			[[fallthrough]];

--- a/SimpleCom/SerialConnection.h
+++ b/SimpleCom/SerialConnection.h
@@ -21,6 +21,7 @@
 #include "stdafx.h"
 #include "SerialPortWriter.h"
 #include "LogWriter.h"
+#include "WinAPIException.h"
 
 
 namespace SimpleCom {
@@ -36,17 +37,20 @@ namespace SimpleCom {
 		bool _useTTYResizer;
 		LogWriter* _logwriter;
 		bool _enableStdinLogging;
+		concurrency::concurrent_queue<WinAPIException> _exception_queue;
 
 		void InitSerialPort(const HANDLE hSerial);
 		bool ShouldTerminate(SerialPortWriter& writer, const HANDLE hTermEvent);
 		void ProcessKeyEvents(const KEY_EVENT_RECORD keyevent, SerialPortWriter& writer);
 		bool StdInRedirector(const HANDLE hSerial, const HANDLE hTermEvent);
 
+		friend DWORD WINAPI StdOutRedirector(_In_ LPVOID lpParameter);
+
 	public:
 		SerialConnection(TString& device, DCB* dcb, HWND hwnd, HANDLE hStdIn, HANDLE hStdOut, bool useTTYResizer, LPCTSTR logfilename, bool enableStdinLogging);
 		virtual ~SerialConnection();
 
-		bool DoSession();
+		bool DoSession(bool allowDetachDevice);
 	};
 
 }

--- a/SimpleCom/SerialPortWriter.cpp
+++ b/SimpleCom/SerialPortWriter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, 2022, Yasumasa Suenaga
+ * Copyright (C) 2021, 2024, Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -62,7 +62,7 @@ void SimpleCom::SerialPortWriter::WriteAsync()
 	DWORD last_error = GetLastError();
 
 	if (!result && (last_error != ERROR_IO_PENDING)) {
-		throw WinAPIException(last_error);
+		throw SerialAPIException(last_error);
 	}
 
 	_buf_idx = 0;
@@ -89,6 +89,6 @@ void SimpleCom::SerialPortWriter::PutData(const char *data, const int len) {
 	DWORD last_error = GetLastError();
 
 	if (!result && (last_error != ERROR_IO_PENDING)) {
-		throw WinAPIException(last_error);
+		throw SerialAPIException(last_error);
 	}
 }

--- a/SimpleCom/SimpleCom.cpp
+++ b/SimpleCom/SimpleCom.cpp
@@ -135,7 +135,7 @@ int _tmain(int argc, LPCTSTR argv[])
 	try {
 		while (true) {
 			SimpleCom::SerialConnection conn(device, &dcb, parent_hwnd, std::get<0>(std_handles), std::get<1>(std_handles), setup.GetUseTTYResizer(), setup.GetLogFile(), setup.IsEnableStdinLogging());
-			bool exited = conn.DoSession();
+			bool exited = conn.DoSession(setup.GetAutoReconnect());
 
 			if (setup.GetAutoReconnect() && !exited) {
 				SimpleCom::debug::log(_T("Sleep before reconnecting..."));

--- a/SimpleCom/WinAPIException.h
+++ b/SimpleCom/WinAPIException.h
@@ -42,6 +42,10 @@ namespace SimpleCom {
 		WinAPIException(const WinAPIException& ex) : _error_code(ex._error_code), _error_caption(ex._error_caption), _error_text(ex._error_text) {}
 		virtual ~WinAPIException() {};
 
+		virtual bool IsSerialAPIException() {
+			return false;
+		}
+
 		inline DWORD GetErrorCode() const noexcept {
 			return _error_code;
 		}
@@ -65,6 +69,10 @@ namespace SimpleCom {
 		SerialAPIException(DWORD error_code, LPCTSTR error_caption) : WinAPIException(error_code, error_caption) {}
 		SerialAPIException(const SerialAPIException& ex) : WinAPIException(ex) {}
 		virtual ~SerialAPIException() {};
+
+		virtual bool IsSerialAPIException() {
+			return true;
+		}
 	};
 
 }

--- a/SimpleCom/WinAPIException.h
+++ b/SimpleCom/WinAPIException.h
@@ -39,7 +39,6 @@ namespace SimpleCom {
 		WinAPIException(LPCTSTR error_caption, LPCTSTR error_text) : _error_code(-1), _error_caption(error_caption), _error_text(error_text) {}
 		WinAPIException(DWORD error_code) : WinAPIException(error_code, _T("SimpleCom")) {}
 		WinAPIException(DWORD error_code, LPCTSTR error_caption);
-		WinAPIException(const WinAPIException& ex) : _error_code(ex._error_code), _error_caption(ex._error_caption), _error_text(ex._error_text) {}
 		virtual ~WinAPIException() {};
 
 		virtual bool IsSerialAPIException() {
@@ -67,7 +66,6 @@ namespace SimpleCom {
 	public:
 		SerialAPIException(DWORD error_code) : WinAPIException(error_code) {}
 		SerialAPIException(DWORD error_code, LPCTSTR error_caption) : WinAPIException(error_code, error_caption) {}
-		SerialAPIException(const SerialAPIException& ex) : WinAPIException(ex) {}
 		virtual ~SerialAPIException() {};
 
 		virtual bool IsSerialAPIException() {

--- a/SimpleCom/WinAPIException.h
+++ b/SimpleCom/WinAPIException.h
@@ -35,13 +35,12 @@ namespace SimpleCom {
 		TString _error_text;
 
 	public:
-		explicit WinAPIException(LPCTSTR error_caption, LPCTSTR error_text) : _error_code(-1), _error_caption(error_caption), _error_text(error_text) {}
-		explicit WinAPIException(DWORD error_code) : WinAPIException(error_code, _T("SimpleCom")) {}
-		explicit WinAPIException(DWORD error_code, LPCTSTR error_caption);
-		WinAPIException(const WinAPIException &ex) : _error_code(ex._error_code), _error_caption(ex._error_caption), _error_text(ex._error_text) {}
+		WinAPIException() : _error_code(-1), _error_caption(nullptr), _error_text() {}
+		WinAPIException(LPCTSTR error_caption, LPCTSTR error_text) : _error_code(-1), _error_caption(error_caption), _error_text(error_text) {}
+		WinAPIException(DWORD error_code) : WinAPIException(error_code, _T("SimpleCom")) {}
+		WinAPIException(DWORD error_code, LPCTSTR error_caption);
+		WinAPIException(const WinAPIException& ex) : _error_code(ex._error_code), _error_caption(ex._error_caption), _error_text(ex._error_text) {}
 		virtual ~WinAPIException() {};
-
-		WinAPIException& operator = (WinAPIException& rvalue) = delete;
 
 		inline DWORD GetErrorCode() const noexcept {
 			return _error_code;
@@ -54,6 +53,18 @@ namespace SimpleCom {
 		inline TString GetErrorText() const noexcept {
 			return _error_text;
 		}
+	};
+
+	/*
+	 * Exception class for Windows API error which relates to serial communication.
+	 */
+	class SerialAPIException : public WinAPIException
+	{
+	public:
+		SerialAPIException(DWORD error_code) : WinAPIException(error_code) {}
+		SerialAPIException(DWORD error_code, LPCTSTR error_caption) : WinAPIException(error_code, error_caption) {}
+		SerialAPIException(const SerialAPIException& ex) : WinAPIException(ex) {}
+		virtual ~SerialAPIException() {};
 	};
 
 }

--- a/SimpleCom/stdafx.h
+++ b/SimpleCom/stdafx.h
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <string>
 #include <codecvt>
+#include <concurrent_queue.h>
 
 #ifdef _UNICODE
 typedef std::wstring TString;


### PR DESCRIPTION
According to [serial communication implementation in .NET Reference Source](https://github.com/microsoft/referencesource/blob/51cf7850defa8a17d815b4700b67116e3fa283c2/System/sys/system/IO/ports/SerialStream.cs#L1739-L1748), following error codes would be reported when serial controller is detached. So we can handle them specially for auto reconnection.

Closes #51