### PR TITLE
Re-enable CodeQL for TTY Resizer

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -91,7 +91,10 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: Build TTY Resizer
-      run: make -C tty-resizer
+      working-directory: tty-resizer
+      run: |
+        bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h
+        make
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,38 +61,37 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
 
-#
+
 # analyze-tty-resizer should be activated when Linux GH runner has v6.0 kernel or later.
 #    https://github.com/torvalds/linux/commit/fcb14cb1bdacec5b4374fe161e83fb8208164a85
-#
-#  analyze-tty-resizer:
-#    runs-on: ubuntu-latest
-#    permissions:
-#      actions: read
-#      contents: read
-#      security-events: write
-#
-#    strategy:
-#      fail-fast: false
-#
-#    steps:
-#    - name: Setup
-#      run: |
-#        sudo apt-get update
-#        sudo apt-get install -y libbpf-dev linux-tools-common
-#
-#    - name: Checkout repository
-#      uses: actions/checkout@v4.1.1
-#
-#    # Initializes the CodeQL tools for scanning.
-#    - name: Initialize CodeQL
-#      uses: github/codeql-action/init@v3
-#      with:
-#        languages: cpp
-#        queries: security-extended,security-and-quality
-#
-#    - name: Build TTY Resizer
-#      run: make -C tty-resizer
-#
-#    - name: Perform CodeQL Analysis
-#      uses: github/codeql-action/analyze@v3
+  analyze-tty-resizer:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Setup
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libbpf-dev linux-tools-common
+
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: cpp
+        queries: security-extended,security-and-quality
+
+    - name: Build TTY Resizer
+      run: make -C tty-resizer
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
According to [Documentation of Ubuntu on GitHub Actions Runner](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md), Ubuntu 24.04 runner has Linux Kernel 6.0. So I re-enable CodeQL check for TTY Resizer.